### PR TITLE
Add lib_measure: operations over alternatives that carry a measure

### DIFF
--- a/examples/measure.metta
+++ b/examples/measure.metta
@@ -1,0 +1,46 @@
+;lib_measure: alternatives that carry a measure, and the operations over them.
+;
+;A weighted superposition is a tuple of (weight value) pairs. The same shape
+;reads as a distribution, as attention weights, as a beam, or as a set of
+;annotated disjunctions, depending only on which operation you apply.
+
+!(import! &self ../lib/lib_measure)
+
+;The mass, and scaling it to one:
+!(test (ws-total ((0.25 a) (0.75 b))) 1.0)
+!(test (ws-normalize ((1.0 a) (3.0 b))) ((0.25 a) (0.75 b)))
+!(test (ws-normalize ()) ())
+
+;An empty mass has no distribution, and says so rather than dividing:
+!(test (ws-normalize ((0.0 a))) (Error ((0.0 a)) "ws-normalize requires nonzero total mass"))
+
+;Softmax over equal scores is uniform, whatever the temperature:
+!(test (ws-softmax ((1.0 a) (1.0 b)) 1.0) ((0.5 a) (0.5 b)))
+!(test (ws-softmax ((1.0 a) (1.0 b)) 0.0)
+       (Error ((1.0 a) (1.0 b)) "ws-softmax requires a nonzero temperature"))
+
+;The heaviest value, which is softmax's zero-temperature limit:
+!(test (ws-best ((0.2 a) (0.5 c) (0.3 b))) c)
+
+;Best-first order, and beam search's keep rule over it:
+!(test (ws-ranked ((0.2 a) (0.5 c) (0.3 b))) ((0.5 c) (0.3 b) (0.2 a)))
+!(test (ws-top ((0.2 a) (0.5 c) (0.3 b)) 2) ((0.5 c) (0.3 b)))
+!(test (ws-top ((0.2 a)) 5) ((0.2 a)))
+!(test (ws-top ((0.2 a)) 0) ())
+
+;Two explanations for one conclusion are one conclusion carrying both weights:
+!(test (ws-collapse ((0.2 a) (0.3 b) (0.5 a))) ((0.7 a) (0.3 b)))
+
+;The expected value of a numeric superposition:
+!(test (ws-expect ((0.5 2.0) (0.5 4.0))) 3.0)
+
+;Pairs above a weight, and the flip for sources that answer value-first:
+!(test (ws-filter ((0.2 a) (0.6 b)) 0.5) ((0.6 b)))
+!(test (ws-flip ((a 0.2) (b 0.6))) ((0.2 a) (0.6 b)))
+
+;The nondeterministic reading: each pair is one alternative:
+!(test (collapse (ws-choose ((0.2 a) (0.6 b)))) ((0.2 a) (0.6 b)))
+
+;Sampling executes the choice. A one-pair superposition has one outcome, so
+;the draw is checkable without pinning a seed:
+!(test (ws-sample! ((1.0 only))) only)

--- a/lib/lib_measure.metta
+++ b/lib/lib_measure.metta
@@ -1,0 +1,95 @@
+;Weighted superpositions: alternatives that carry a measure.
+;
+;A weighted superposition is a tuple of (weight value) pairs, the head shape
+;of an annotated disjunction in probabilistic logic programming (Vennekens,
+;Verbaeten, Bruynooghe, "Logic Programs with Annotated Disjunctions", ICLP
+;2004; Sato's distribution semantics underneath). The operations here are the
+;measure algebra those programs and modern attention share: normalize is a
+;distribution, softmax with a temperature is attention's own weighting
+;(Ramsauer et al., "Hopfield Networks is All You Need"), sampling executes the
+;probabilistic choice, argmax is the zero-temperature limit, and top-k is beam
+;search's keep rule. One representation, every reading.
+
+;The mass of a weighted superposition. foldl-atom's list parameter is
+;Expression, so it holds its operand as written; the mapped weights are NAMED
+;and the name handed over.
+(= (ws-total $ps)
+   (let $weights (map-atom $ps (|-> ($p) (index-atom $p 0)))
+     (foldl-atom $weights 0.0 +)))
+
+;Scale every weight so the mass is one; a distribution:
+(= (ws-normalize $ps)
+   (if (== $ps ())
+       ()
+       (let $t (ws-total $ps)
+            (if (<= (abs-math $t) 0.0)
+                (Error $ps "ws-normalize requires nonzero total mass")
+                (map-atom $ps
+                  (|-> ($p) ((/ (index-atom $p 0) $t)
+                              (index-atom $p 1))))))))
+
+;Softmax with a temperature: scores become a distribution. Low temperature
+;sharpens toward the best pair, high temperature flattens toward uniform.
+(= (ws-softmax $ps $temp)
+   (if (<= (abs-math $temp) 0.0)
+       (Error $ps "ws-softmax requires a nonzero temperature")
+       (ws-normalize
+         (map-atom $ps (|-> ($p) ((exp (/ (index-atom $p 0) $temp))
+                                  (index-atom $p 1)))))))
+
+;The pair with more weight, then the best value; the temperature-zero limit:
+(= (ws-pickmax $a $b) (if (>= (index-atom $a 0) (index-atom $b 0)) $a $b))
+(= (ws-best $ps)
+   (let $rest (cdr-atom $ps)
+     (let $first (car-atom $ps)
+       (let $best (foldl-atom $rest $first ws-pickmax)
+         (index-atom $best 1)))))
+
+;Pairs sorted best-first, and the first k of them, beam search's keep rule:
+(= (ws-ranked $ps) (reverse (sort-atom $ps)))
+(= (ws-take $ps $k)
+   (if (or (== $ps ()) (<= $k 0))
+       ()
+       (let ($h $t) (decons-atom $ps)
+            (let $rest (ws-take $t (- $k 1))
+              (cons-atom $h $rest)))))
+(= (ws-top $ps $k) (ws-take (ws-ranked $ps) $k))
+
+;Draw one value with probability proportional to its weight: the annotated
+;disjunction's choice, executed.
+(= (ws-sample! $ps)
+   (ws-sample-walk $ps (random-float 0.0 (ws-total $ps))))
+(= (ws-sample-walk $ps $u)
+   (let ($h $t) (decons-atom $ps)
+        (if (or (== $t ()) (< $u (index-atom $h 0)))
+            (index-atom $h 1)
+            (ws-sample-walk $t (- $u (index-atom $h 0))))))
+
+;Merge pairs carrying the same value, adding their weights: the summing of
+;explanations for one conclusion.
+(= (ws-merge-into $acc $p)
+   (if (== $acc ())
+       ($p)
+       (let ($h $t) (decons-atom $acc)
+            (if (== (index-atom $h 1) (index-atom $p 1))
+                (let $summed (+ (index-atom $h 0) (index-atom $p 0))
+                  (let $value (index-atom $h 1)
+                    (cons-atom ($summed $value) $t)))
+                (let $rest (ws-merge-into $t $p)
+                  (cons-atom $h $rest))))))
+(= (ws-collapse $ps) (foldl-atom $ps () ws-merge-into))
+
+;The expected value of a numeric weighted superposition:
+(= (ws-expect $ps)
+   (let $terms (map-atom $ps (|-> ($p) (* (index-atom $p 0) (index-atom $p 1))))
+     (foldl-atom $terms 0.0 +)))
+
+;Nondeterministic reading: each pair is one alternative, measure as data:
+(= (ws-choose $ps) (superpose $ps))
+
+;Pairs above a weight, and (score value) from (value score), for sources
+;such as knn retrieval that answer value-first:
+(= (ws-filter $ps $least)
+   (filter-atom $ps (|-> ($p) (>= (index-atom $p 0) $least))))
+(= (ws-flip $ps)
+   (map-atom $ps (|-> ($p) ((index-atom $p 1) (index-atom $p 0)))))


### PR DESCRIPTION
A weighted superposition is a tuple of `(weight value)` pairs:

```metta
!(import! &self ../lib/lib_measure)

!(ws-normalize ((1.0 a) (3.0 b)))          ; ((0.25 a) (0.75 b))
!(ws-best ((0.2 a) (0.5 c) (0.3 b)))       ; c
!(ws-top ((0.2 a) (0.5 c) (0.3 b)) 2)      ; ((0.5 c) (0.3 b))
!(ws-collapse ((0.2 a) (0.3 b) (0.5 a)))   ; ((0.7 a) (0.3 b))
```

That is the head shape of an annotated disjunction in probabilistic logic
programming (Vennekens, Verbaeten and Bruynooghe, ICLP 2004, over Sato's
distribution semantics). It is also what attention weights are, what a beam
is, and what ranked retrieval answers. This library is the algebra those
readings share, so one representation serves all of them:

| operation | the reading it gives |
|---|---|
| `ws-normalize` | a distribution |
| `ws-softmax` | attention's own weighting, at a temperature |
| `ws-best` | softmax's zero-temperature limit |
| `ws-ranked`, `ws-top` | beam search's keep rule |
| `ws-sample!` | the probabilistic choice, executed |
| `ws-collapse` | the explanations for one conclusion, summed |
| `ws-expect` | the expected value |
| `ws-choose` | each pair as one nondeterministic alternative |

**Pure MeTTa, no engine change.** It rests on `map-atom`, `foldl-atom`,
`filter-atom`, `index-atom`, the cons/decons pair, `sort-atom`, `reverse`,
`abs-math`, `exp`, `random-float` and `superpose`, all of which PeTTa already
has. No Prolog file, no new builtin.

**Refusals rather than silence.** Normalizing zero total mass and a softmax at
zero temperature each answer an `Error` naming the requirement, instead of
dividing.

`examples/measure.metta` exercises every operation, both refusals, and the
empty and single-pair edges. It pins no seed: `ws-sample!` over a one-pair
superposition has exactly one outcome, so the draw is checkable without one.

`sh test.sh` passes 159 examples with no failure, `measure.metta` among them.